### PR TITLE
Add Ruby 3.3.6

### DIFF
--- a/ruby/3.2.5/Dockerfile
+++ b/ruby/3.2.5/Dockerfile
@@ -13,13 +13,13 @@ RUN apt-get update &&  \
 COPY install-certs.sh .
 RUN bash install-certs.sh && update-ca-certificates
 
-# Install PostgreSQL 12
+# Install PostgreSQL 13
 RUN apt-get update && \
     apt-get install -y lsb-release && \
     echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     apt-get install -y postgresql-common && \
     yes '' | /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh && \
-    apt-get install -y postgresql-12
+    apt-get install -y postgresql-13
 
 # Install Node.js using the NodeSource setup script
 ARG NODE_MAJOR_VERSION=22

--- a/ruby/3.3.6/Dockerfile
+++ b/ruby/3.3.6/Dockerfile
@@ -1,5 +1,5 @@
 ARG RELEASE=bullseye
-FROM ruby:3.3.6-slim-${RELEASE} as rubyimg
+FROM ruby:3.2.5-slim-${RELEASE} as rubyimg
 
 # Install necessary packages and clean up
 RUN apt-get update &&  \

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,6 +1,7 @@
 # Agile Six Applications, Inc. flavored Dockerfiles - Ruby
 
 ### Ruby
+- 3.2.5 Updates Node to 22
 - 2.5.3: adds Imagemagick 7+
 - 2.6.3: adds Imagemagick 7+
   - -centos7.6 uses agilesix's centos:7.6 base image, with Imagemagick 7+


### PR DESCRIPTION
- [x] Confirm that Ruby 3.3.6 is available in [upstream Docker images](https://hub.docker.com/_/ruby)